### PR TITLE
update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,6 @@ When I was a budding developer there were a few occassions where I created a rep
 
 8. Now that you have your local and remote repositories setup and connected, its time to take a look at some best practices for developing. This is especially important for developing projects with other human beings. 
 
-   <a href="http://nvie.com/posts/a-successful-git-branching-model/" target="_blank">Click here for "A Successful Git Branching Model" by Vincent Driessen</a>
+   [Click here for "A Successful Git Branching Model" by Vincent Driessen](http://nvie.com/posts/a-successful-git-branching-model/)
 
 


### PR DESCRIPTION
ok, so apparently Markdown does not allow "target = _blank" links even when using HTML syntax, so I changed the code back to normal Markdown.